### PR TITLE
Add Claude Code skills (branch, draft-pr, issue)

### DIFF
--- a/.claude/skills/branch/SKILL.md
+++ b/.claude/skills/branch/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: branch
+description: Issue番号からfeatureブランチを作成してチェックアウトする。番号未指定の場合は現在の差分から推測する
+argument-hint: [issue-number]
+allowed-tools: Bash(git *), Bash(gh *)
+---
+
+# ブランチ作成
+
+## Issue番号が指定された場合
+
+`main` から `feature/issue-$ARGUMENTS` ブランチを作成してチェックアウトする。
+
+```
+git checkout main
+git pull origin main
+git checkout -b feature/issue-$ARGUMENTS
+```
+
+## Issue番号が指定されなかった場合
+
+1. `git status`、`git diff`、`git diff --cached` で現在の差分を確認する。未追跡ファイルが存在する場合はその内容も確認する
+2. `gh issue list --repo inoue2302/ai-pr-split-demo --state open` で open な Issue 一覧を取得する
+3. 差分の内容と Issue 一覧を照合し、最も関連性の高い Issue 番号を特定する
+4. 該当する Issue があれば `feature/issue-{N}` ブランチを作成する
+5. 該当する Issue がない場合は、差分の内容から適切なブランチ名を `feature/{変更内容の要約}` 形式で決定し、ブランチを作成する
+6. 差分もない場合はユーザーに確認する

--- a/.claude/skills/draft-pr/SKILL.md
+++ b/.claude/skills/draft-pr/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: draft-pr
+description: 現在のブランチの差分からドラフトPRを作成する。実行前に必ずユーザーに確認する
+disable-model-invocation: true
+allowed-tools: Bash(git *), Bash(gh *)
+---
+
+# ドラフト PR 作成
+
+## 手順
+
+1. **差分の収集**
+   - `git log main..HEAD --oneline` でコミット一覧を取得
+   - `git diff main...HEAD` で差分を取得
+   - 現在のブランチ名を確認する
+
+2. **PR 内容の作成**
+   - 差分とコミット履歴から PR タイトルと本文を作成する
+   - ブランチ名に Issue 番号が含まれていれば（`feature/issue-N`）、本文に `Closes #N` を含める
+   - 本文は以下のフォーマットに従う:
+     ```
+     ## Summary
+     - 変更内容の箇条書き
+
+     ## Test plan
+     - テスト方法のチェックリスト
+     ```
+
+3. **ユーザーに確認（必須）**
+   実行する `gh pr create` コマンドの全文をユーザーに提示し、承認を得てから実行する。
+   コマンドは以下の形式:
+   ```
+   gh pr create --draft --title "タイトル" --body "本文"
+   ```
+   **確認なしに PR を作成してはならない。**
+
+4. **PR 作成**
+   ユーザーの承認後にコマンドを実行し、PR の URL を表示する。

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: issue
+description: GitHub Issueを読み込み、内容に従って実装・コミット・PR作成まで行う
+argument-hint: [issue-number]
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash(gh *), Bash(git *), Bash(npm *), Bash(npx *)
+---
+
+# GitHub Issue #$ARGUMENTS の対応
+
+## 手順
+
+1. **Issue の読み込み**
+   以下のコマンドで Issue の内容を取得する:
+   ```
+   gh issue view $ARGUMENTS --repo inoue2302/ai-pr-split-demo
+   ```
+
+2. **作業ブランチの作成**
+   - Issue の内容に基づいて適切なブランチ名を決める（例: `feat/issue-$ARGUMENTS-short-description`）
+   - `main` から新しいブランチを作成してチェックアウトする
+
+3. **実装**
+   - Issue の「やること」に従って実装する
+   - CLAUDE.md のコンベンションに従う
+   - 変更は最小限に、Issue の要求のみ対応する
+
+4. **動作確認**
+   - 型チェック: `npx tsc --noEmit`
+   - 必要に応じてビルド: `npm run build`
+
+5. **コミット**
+   - 変更内容に応じて適切な粒度でコミットする
+   - コミットメッセージは変更内容を端的に表す
+
+6. **PR 作成**
+   - `gh pr create` で PR を作成する
+   - PR の description に Issue 番号を含める（`Closes #$ARGUMENTS`）
+   - PR の URL を表示する


### PR DESCRIPTION
## Summary
- Claude Code用のカスタムスキル3つを追加
  - **branch**: Issue番号からfeatureブランチを作成（番号未指定時は差分から推測）
  - **draft-pr**: 現在のブランチの差分からドラフトPR を作成
  - **issue**: GitHub Issueを読み込み、実装・コミット・PR作成まで実行