### PR TITLE
TODO作成APIのアプリケーション層を実装

### DIFF
--- a/src/todo/application/create-todo.usecase.ts
+++ b/src/todo/application/create-todo.usecase.ts
@@ -1,13 +1,27 @@
 import type { CreateTodoInput, TodoResponse } from './dto/create-todo.dto.js'
+import { insertTodo, findTodoByTitle } from '../infrastructure/todo.repository.js'
 
-export function createTodo(input: CreateTodoInput): TodoResponse {
-  // モック（後続PRでインフラ層のリポジトリに置き換え）
-  const now = new Date().toISOString()
-  return {
-    id: 1,
-    title: input.title,
-    completed: false,
-    createdAt: now,
-    updatedAt: now,
+function normalizeTitle(title: string): string {
+  return title
+    .trim()
+    .replace(/\u3000/g, ' ')
+    .replace(/ {2,}/g, ' ')
+}
+
+export async function createTodo(input: CreateTodoInput): Promise<TodoResponse> {
+  const title = normalizeTitle(input.title)
+
+  const existing = await findTodoByTitle(title)
+  if (existing) {
+    throw new DuplicateTodoError(title)
+  }
+
+  return await insertTodo({ title })
+}
+
+export class DuplicateTodoError extends Error {
+  constructor(title: string) {
+    super(`同じタイトルのTodoが既に存在します: ${title}`)
+    this.name = 'DuplicateTodoError'
   }
 }

--- a/src/todo/infrastructure/todo.repository.ts
+++ b/src/todo/infrastructure/todo.repository.ts
@@ -16,3 +16,19 @@ export async function insertTodo(input: CreateTodoInput): Promise<TodoResponse> 
     updatedAt: todo.updatedAt.toISOString(),
   }
 }
+
+export async function findTodoByTitle(title: string): Promise<TodoResponse | null> {
+  const todo = await prisma.todo.findFirst({
+    where: { title },
+  })
+
+  if (!todo) return null
+
+  return {
+    id: todo.id,
+    title: todo.title,
+    completed: todo.completed,
+    createdAt: todo.createdAt.toISOString(),
+    updatedAt: todo.updatedAt.toISOString(),
+  }
+}

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { createTodoSchema } from '../application/dto/create-todo.dto.js'
-import { createTodo } from '../application/create-todo.usecase.js'
+import { createTodo, DuplicateTodoError } from '../application/create-todo.usecase.js'
 
 const todoRoute = new Hono()
 
@@ -12,8 +12,15 @@ todoRoute.post('/', async (c) => {
     return c.json({ errors: parsed.error.flatten().fieldErrors }, 400)
   }
 
-  const todo = createTodo(parsed.data)
-  return c.json(todo, 201)
+  try {
+    const todo = await createTodo(parsed.data)
+    return c.json(todo, 201)
+  } catch (e) {
+    if (e instanceof DuplicateTodoError) {
+      return c.json({ message: e.message }, 400)
+    }
+    throw e
+  }
 })
 
 export { todoRoute }


### PR DESCRIPTION
## 概要
インフラ層のrepositoryをアプリケーション層から呼び出し、ビジネスロジック（タイトル正規化・重複チェック）を実装。

## 特に見てほしい点
- タイトル正規化のルール（トリム、全角スペース→半角、連続空白除去）
- 重複チェックの実装方法（findTodoByTitle → DuplicateTodoError）
- プレゼンテーション層でのエラーハンドリング

## 実装内容

```
src/todo/
├── application/
│   └── create-todo.usecase.ts     # タイトル正規化 + 重複チェック + repository呼び出し
├── infrastructure/
│   └── todo.repository.ts         # findTodoByTitle を追加
└── presentation/
    └── todo.route.ts              # await対応 + DuplicateTodoError ハンドリング
```

### 動作確認
```
POST {"title":"  テスト　Todo  "}  → 201 {"title":"テスト Todo"} (正規化)
POST {"title":"テスト Todo"}       → 400 {"message":"同じタイトルのTodoが既に存在します: テスト Todo"}
```

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)