### PR TITLE
[1/3] エンドポイント & DTO定義（モック実装）

### DIFF
--- a/src/todo/application/dto/list-todos-query.dto.ts
+++ b/src/todo/application/dto/list-todos-query.dto.ts
@@ -3,8 +3,8 @@ import { z } from 'zod'
 export const listTodosQuerySchema = z.object({
   completed: z
     .enum(['true', 'false'])
-    .transform((v) => v === 'true')
+    .transform((value) => value === 'true')
     .optional(),
-})
+}).strict()
 
 export type ListTodosQuery = z.infer<typeof listTodosQuerySchema>

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -17,27 +17,29 @@ todoRoute.get('/', async (c) => {
   }
 
   // TODO: Replace with usecase
-  const mock: TodoResponse[] = [
+  const mockTodos: TodoResponse[] = [
     { id: 1, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' },
   ]
   const filtered = parsed.data.completed !== undefined
-    ? mock.filter((t) => t.completed === parsed.data.completed)
-    : mock
+    ? mockTodos.filter((t) => t.completed === parsed.data.completed)
+    : mockTodos
   return c.json(filtered)
 })
 
 todoRoute.get('/:id', async (c) => {
-  const id = Number(c.req.param('id'))
-  if (!Number.isInteger(id) || id <= 0) {
+  const idStr = c.req.param('id')
+  const id = parseInt(idStr, 10)
+  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
   // TODO: Replace with usecase
-  const mock: TodoResponse = { id, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
-  if (id === 999) {
-    return c.json({ message: 'Todoが見つかりません: ' + id }, 404)
+  const MOCK_NOT_FOUND_ID = 999
+  if (id === MOCK_NOT_FOUND_ID) {
+    return c.json({ message: `Todoが見つかりません: ${id}` }, 404)
   }
-  return c.json(mock)
+  const mockTodo: TodoResponse = { id, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
+  return c.json(mockTodo)
 })
 
 todoRoute.post('/', async (c) => {


### PR DESCRIPTION
## 概要
`GET /api/todos`（一覧取得）と `GET /api/todos/:id`（単件取得）のエンドポイントを定義し、モックレスポンスを返す。

## 親Issue
#25 TODO取得API

## 関連PR
- 前: なし（base: main）
- 次: 未作成

## 変更内容
- `listTodosQuerySchema` を追加（`completed` クエリパラメータのバリデーション）
- `GET /api/todos` ハンドラ追加（モックデータ返却、`completed` フィルタ対応）
- `GET /api/todos/:id` ハンドラ追加（モックデータ返却、IDバリデーション、404定義）

---
Closes #26