### PR TITLE
[2/3] インフラ層（Repository実装）

### DIFF
--- a/src/todo/infrastructure/todo.repository.ts
+++ b/src/todo/infrastructure/todo.repository.ts
@@ -41,6 +41,15 @@ export async function updateTodo(id: number, input: UpdateTodoInput): Promise<To
   return toTodoResponse(todo)
 }
 
+export async function findAllTodos(filter?: { completed?: boolean }): Promise<TodoResponse[]> {
+  const todos = await prisma.todo.findMany({
+    where: filter?.completed !== undefined ? { completed: filter.completed } : undefined,
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return todos.map(toTodoResponse)
+}
+
 export async function findTodoByTitle(title: string): Promise<TodoResponse | null> {
   const todo = await prisma.todo.findFirst({
     where: { title },


### PR DESCRIPTION
## 概要
`findAllTodos` をRepositoryに追加し、一覧取得のDBクエリを実装する。

## 親Issue
#25 TODO取得API

## 関連PR
- 前: #29（このPRのbase）
- 次: 未作成

## 変更内容
- `findAllTodos(filter?: { completed?: boolean })` を `todo.repository.ts` に追加
- Prisma `findMany` で `completed` フィルタ対応、`createdAt` 降順ソート
- 既存の `toTodoResponse` ヘルパーを再利用

---
Closes #27