### PR TITLE
[3/3] アプリケーション層 + テスト

### DIFF
--- a/src/__tests__/get-todo.test.ts
+++ b/src/__tests__/get-todo.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { app } from '../app.js'
+import { prisma } from '../lib/prisma.js'
+import { cleanDatabase } from './setup.js'
+
+describe('GET /api/todos/:id', () => {
+  beforeEach(async () => {
+    await cleanDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanDatabase()
+    await prisma.$disconnect()
+  })
+
+  it('IDを指定してTodoを取得できる', async () => {
+    const createRes = await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '取得テスト' }),
+    })
+    const created = await createRes.json()
+
+    const res = await app.request(`/api/todos/${created.id}`)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.id).toBe(created.id)
+    expect(body.title).toBe('取得テスト')
+  })
+
+  it('存在しないIDで404を返す', async () => {
+    const res = await app.request('/api/todos/99999')
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toContain('Todoが見つかりません')
+  })
+
+  it('不正なIDで400を返す', async () => {
+    const res = await app.request('/api/todos/-1')
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toContain('IDは正の整数で指定してください')
+  })
+})

--- a/src/__tests__/list-todos.test.ts
+++ b/src/__tests__/list-todos.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { app } from '../app.js'
+import { prisma } from '../lib/prisma.js'
+import { cleanDatabase } from './setup.js'
+
+describe('GET /api/todos', () => {
+  beforeEach(async () => {
+    await cleanDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanDatabase()
+    await prisma.$disconnect()
+  })
+
+  it('Todo一覧を取得できる', async () => {
+    await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Todo1' }),
+    })
+    await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Todo2' }),
+    })
+
+    const res = await app.request('/api/todos')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(2)
+  })
+
+  it('Todoが0件の場合は空配列を返す', async () => {
+    const res = await app.request('/api/todos')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(0)
+  })
+
+  it('completedフィルタで絞り込める', async () => {
+    const createRes = await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '完了済み' }),
+    })
+    const created = await createRes.json()
+    await app.request(`/api/todos/${created.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ completed: true }),
+    })
+    await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '未完了' }),
+    })
+
+    const res = await app.request('/api/todos?completed=true')
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].title).toBe('完了済み')
+  })
+})

--- a/src/todo/application/dto/list-todos-query.dto.ts
+++ b/src/todo/application/dto/list-todos-query.dto.ts
@@ -3,8 +3,8 @@ import { z } from 'zod'
 export const listTodosQuerySchema = z.object({
   completed: z
     .enum(['true', 'false'])
-    .transform((v) => v === 'true')
+    .transform((value) => value === 'true')
     .optional(),
-})
+}).strict()
 
 export type ListTodosQuery = z.infer<typeof listTodosQuerySchema>

--- a/src/todo/application/get-todo.usecase.ts
+++ b/src/todo/application/get-todo.usecase.ts
@@ -1,0 +1,11 @@
+import type { TodoResponse } from './dto/create-todo.dto.js'
+import { findTodoById } from '../infrastructure/todo.repository.js'
+import { TodoNotFoundError } from './errors.js'
+
+export async function getTodo(id: number): Promise<TodoResponse> {
+  const todo = await findTodoById(id)
+  if (!todo) {
+    throw new TodoNotFoundError(id)
+  }
+  return todo
+}

--- a/src/todo/application/list-todos.usecase.ts
+++ b/src/todo/application/list-todos.usecase.ts
@@ -1,0 +1,6 @@
+import type { TodoResponse } from './dto/create-todo.dto.js'
+import { findAllTodos } from '../infrastructure/todo.repository.js'
+
+export async function listTodos(filter?: { completed?: boolean }): Promise<TodoResponse[]> {
+  return await findAllTodos(filter)
+}

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -17,27 +17,29 @@ todoRoute.get('/', async (c) => {
   }
 
   // TODO: Replace with usecase
-  const mock: TodoResponse[] = [
+  const mockTodos: TodoResponse[] = [
     { id: 1, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' },
   ]
   const filtered = parsed.data.completed !== undefined
-    ? mock.filter((t) => t.completed === parsed.data.completed)
-    : mock
+    ? mockTodos.filter((t) => t.completed === parsed.data.completed)
+    : mockTodos
   return c.json(filtered)
 })
 
 todoRoute.get('/:id', async (c) => {
-  const id = Number(c.req.param('id'))
-  if (!Number.isInteger(id) || id <= 0) {
+  const idStr = c.req.param('id')
+  const id = parseInt(idStr, 10)
+  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
   // TODO: Replace with usecase
-  const mock: TodoResponse = { id, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
-  if (id === 999) {
-    return c.json({ message: 'Todoが見つかりません: ' + id }, 404)
+  const MOCK_NOT_FOUND_ID = 999
+  if (id === MOCK_NOT_FOUND_ID) {
+    return c.json({ message: `Todoが見つかりません: ${id}` }, 404)
   }
-  return c.json(mock)
+  const mockTodo: TodoResponse = { id, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
+  return c.json(mockTodo)
 })
 
 todoRoute.post('/', async (c) => {

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -4,8 +4,9 @@ import { updateTodoSchema } from '../application/dto/update-todo.dto.js'
 import { listTodosQuerySchema } from '../application/dto/list-todos-query.dto.js'
 import { createTodo } from '../application/create-todo.usecase.js'
 import { updateTodo } from '../application/update-todo.usecase.js'
+import { getTodo } from '../application/get-todo.usecase.js'
+import { listTodos } from '../application/list-todos.usecase.js'
 import { DuplicateTodoError, TodoNotFoundError } from '../application/errors.js'
-import type { TodoResponse } from '../application/dto/create-todo.dto.js'
 
 const todoRoute = new Hono()
 
@@ -16,14 +17,8 @@ todoRoute.get('/', async (c) => {
     return c.json({ errors: parsed.error.flatten().fieldErrors }, 400)
   }
 
-  // TODO: Replace with usecase
-  const mock: TodoResponse[] = [
-    { id: 1, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' },
-  ]
-  const filtered = parsed.data.completed !== undefined
-    ? mock.filter((t) => t.completed === parsed.data.completed)
-    : mock
-  return c.json(filtered)
+  const todos = await listTodos(parsed.data.completed !== undefined ? { completed: parsed.data.completed } : undefined)
+  return c.json(todos)
 })
 
 todoRoute.get('/:id', async (c) => {
@@ -32,12 +27,15 @@ todoRoute.get('/:id', async (c) => {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
-  // TODO: Replace with usecase
-  const mock: TodoResponse = { id, title: 'サンプルTodo', completed: false, createdAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }
-  if (id === 999) {
-    return c.json({ message: 'Todoが見つかりません: ' + id }, 404)
+  try {
+    const todo = await getTodo(id)
+    return c.json(todo)
+  } catch (e) {
+    if (e instanceof TodoNotFoundError) {
+      return c.json({ message: e.message }, 404)
+    }
+    throw e
   }
-  return c.json(mock)
 })
 
 todoRoute.post('/', async (c) => {


### PR DESCRIPTION
## 概要
`getTodo` / `listTodos` ユースケースを実装し、モックレスポンスをRepository呼び出しに置き換える。インテグレーションテストも追加。

## 親Issue
#25 TODO取得API

## 関連PR
- 前: #30（このPRのbase）
- 次: なし（最後）

## 変更内容
- `get-todo.usecase.ts` — IDでTodo取得、存在しない場合は `TodoNotFoundError`
- `list-todos.usecase.ts` — 全件/フィルタ付き取得
- `todo.route.ts` — GETハンドラのモックをユースケース呼び出しに置き換え
- `get-todo.test.ts` — 単件取得のテスト（正常系 + 404 + 不正ID）
- `list-todos.test.ts` — 一覧取得のテスト（全件 + 0件 + completedフィルタ）

---
Closes #28