### PR TITLE
[1/3] エンドポイント追加（DELETE /api/todos/:id）

### DIFF
--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -9,6 +9,14 @@ import type { TodoResponse } from '../application/dto/create-todo.dto.js'
 
 const todoRoute = new Hono()
 
+function parsePositiveIntId(idStr: string): number | null {
+  const id = parseInt(idStr, 10)
+  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
+    return null
+  }
+  return id
+}
+
 todoRoute.get('/', async (c) => {
   const parsed = listTodosQuerySchema.safeParse(c.req.query())
 
@@ -27,9 +35,8 @@ todoRoute.get('/', async (c) => {
 })
 
 todoRoute.get('/:id', async (c) => {
-  const idStr = c.req.param('id')
-  const id = parseInt(idStr, 10)
-  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
+  const id = parsePositiveIntId(c.req.param('id'))
+  if (id === null) {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
@@ -62,8 +69,8 @@ todoRoute.post('/', async (c) => {
 })
 
 todoRoute.put('/:id', async (c) => {
-  const id = Number(c.req.param('id'))
-  if (!Number.isInteger(id) || id <= 0) {
+  const id = parsePositiveIntId(c.req.param('id'))
+  if (id === null) {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
@@ -95,13 +102,16 @@ todoRoute.put('/:id', async (c) => {
 })
 
 todoRoute.delete('/:id', async (c) => {
-  const idStr = c.req.param('id')
-  const id = parseInt(idStr, 10)
-  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
+  const id = parsePositiveIntId(c.req.param('id'))
+  if (id === null) {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
   // TODO: Replace with usecase
+  const MOCK_NOT_FOUND_ID = 999
+  if (id === MOCK_NOT_FOUND_ID) {
+    return c.json({ message: `Todoが見つかりません: ${id}` }, 404)
+  }
   return c.body(null, 204)
 })
 

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -94,4 +94,15 @@ todoRoute.put('/:id', async (c) => {
   }
 })
 
+todoRoute.delete('/:id', async (c) => {
+  const idStr = c.req.param('id')
+  const id = parseInt(idStr, 10)
+  if (isNaN(id) || id <= 0 || String(id) !== idStr) {
+    return c.json({ message: 'IDは正の整数で指定してください' }, 400)
+  }
+
+  // TODO: Replace with usecase
+  return c.body(null, 204)
+})
+
 export { todoRoute }


### PR DESCRIPTION
## 概要
`DELETE /api/todos/:id` エンドポイントを追加し、IDバリデーションとモック204レスポンスを実装する。

## 親Issue
#32 TODO削除API

## 関連PR
- 前: なし（base: main）
- 次: 未作成

## 変更内容
- `todoRoute.delete('/:id', ...)` ハンドラを追加
- IDバリデーション（既存 `GET /:id` と同じパターン: `parseInt` + 正の整数チェック + 文字列比較）
- 不正なID → 400レスポンス
- モック実装: 常に 204 No Content を返す

---
Closes #33