### PR TITLE
[2/3] インフラ層（deleteTodo repository）

### DIFF
--- a/src/todo/infrastructure/todo.repository.ts
+++ b/src/todo/infrastructure/todo.repository.ts
@@ -1,6 +1,8 @@
+import { Prisma } from '../../generated/prisma/client.js'
 import { prisma } from '../../lib/prisma.js'
 import type { CreateTodoInput, TodoResponse } from '../application/dto/create-todo.dto.js'
 import type { UpdateTodoInput } from '../application/dto/update-todo.dto.js'
+import { TodoNotFoundError } from '../application/errors.js'
 
 function toTodoResponse(todo: { id: number; title: string; completed: boolean; createdAt: Date; updatedAt: Date }): TodoResponse {
   return {
@@ -42,9 +44,16 @@ export async function updateTodo(id: number, input: UpdateTodoInput): Promise<To
 }
 
 export async function deleteTodo(id: number): Promise<void> {
-  await prisma.todo.delete({
-    where: { id },
-  })
+  try {
+    await prisma.todo.delete({
+      where: { id },
+    })
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2025') {
+      throw new TodoNotFoundError(id)
+    }
+    throw e
+  }
 }
 
 export async function findTodoByTitle(title: string): Promise<TodoResponse | null> {

--- a/src/todo/infrastructure/todo.repository.ts
+++ b/src/todo/infrastructure/todo.repository.ts
@@ -41,6 +41,12 @@ export async function updateTodo(id: number, input: UpdateTodoInput): Promise<To
   return toTodoResponse(todo)
 }
 
+export async function deleteTodo(id: number): Promise<void> {
+  await prisma.todo.delete({
+    where: { id },
+  })
+}
+
 export async function findTodoByTitle(title: string): Promise<TodoResponse | null> {
   const todo = await prisma.todo.findFirst({
     where: { title },


### PR DESCRIPTION
## 概要
`deleteTodo` repository関数を追加し、Prismaによる物理削除を実装する。

## 親Issue
#32 TODO削除API

## 関連PR
- 前: #36（このPRのbase）
- 次: 未作成

## 変更内容
- `src/todo/infrastructure/todo.repository.ts` に `deleteTodo(id: number): Promise<void>` を追加
- `prisma.todo.delete({ where: { id } })` で物理削除
- 存在しないIDの場合は Prisma が `P2025` エラーをスローする（呼び出し元のusecaseで事前に存在確認する方針）

---
Closes #34