### PR TITLE
[3/3] アプリケーション層 + テスト（deleteTodo usecase & テスト）

### DIFF
--- a/src/__tests__/delete-todo.test.ts
+++ b/src/__tests__/delete-todo.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { app } from '../app.js'
+import { prisma } from '../lib/prisma.js'
+import { cleanDatabase } from './setup.js'
+
+describe('DELETE /api/todos/:id', () => {
+  beforeEach(async () => {
+    await cleanDatabase()
+  })
+
+  afterAll(async () => {
+    await cleanDatabase()
+    await prisma.$disconnect()
+  })
+
+  it('Todoを削除できる', async () => {
+    const createRes = await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '削除テスト' }),
+    })
+    const created = await createRes.json()
+
+    const res = await app.request(`/api/todos/${created.id}`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(204)
+  })
+
+  it('削除後にDBからレコードが消えている', async () => {
+    const createRes = await app.request('/api/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '削除確認テスト' }),
+    })
+    const created = await createRes.json()
+
+    await app.request(`/api/todos/${created.id}`, {
+      method: 'DELETE',
+    })
+
+    const record = await prisma.todo.findUnique({ where: { id: created.id } })
+    expect(record).toBeNull()
+  })
+
+  it('存在しないIDで404を返す', async () => {
+    const res = await app.request('/api/todos/99999', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toContain('Todoが見つかりません')
+  })
+
+  it('不正なIDで400を返す', async () => {
+    const res = await app.request('/api/todos/-1', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toContain('IDは正の整数で指定してください')
+  })
+})

--- a/src/__tests__/delete-todo.test.ts
+++ b/src/__tests__/delete-todo.test.ts
@@ -3,6 +3,15 @@ import { app } from '../app.js'
 import { prisma } from '../lib/prisma.js'
 import { cleanDatabase } from './setup.js'
 
+async function createTodo(title: string) {
+  const res = await app.request('/api/todos', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+  return res.json()
+}
+
 describe('DELETE /api/todos/:id', () => {
   beforeEach(async () => {
     await cleanDatabase()
@@ -14,14 +23,9 @@ describe('DELETE /api/todos/:id', () => {
   })
 
   it('Todoを削除できる', async () => {
-    const createRes = await app.request('/api/todos', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: '削除テスト' }),
-    })
-    const created = await createRes.json()
+    const todo = await createTodo('削除テスト')
 
-    const res = await app.request(`/api/todos/${created.id}`, {
+    const res = await app.request(`/api/todos/${todo.id}`, {
       method: 'DELETE',
     })
 
@@ -29,19 +33,31 @@ describe('DELETE /api/todos/:id', () => {
   })
 
   it('削除後にDBからレコードが消えている', async () => {
-    const createRes = await app.request('/api/todos', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: '削除確認テスト' }),
-    })
-    const created = await createRes.json()
+    const todo = await createTodo('削除確認テスト')
 
-    await app.request(`/api/todos/${created.id}`, {
+    const res = await app.request(`/api/todos/${todo.id}`, {
       method: 'DELETE',
     })
 
-    const record = await prisma.todo.findUnique({ where: { id: created.id } })
+    expect(res.status).toBe(204)
+    const record = await prisma.todo.findUnique({ where: { id: todo.id } })
     expect(record).toBeNull()
+  })
+
+  it('2回目のDELETEで404を返す', async () => {
+    const todo = await createTodo('べき等性テスト')
+
+    await app.request(`/api/todos/${todo.id}`, {
+      method: 'DELETE',
+    })
+
+    const res = await app.request(`/api/todos/${todo.id}`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.message).toContain('Todoが見つかりません')
   })
 
   it('存在しないIDで404を返す', async () => {
@@ -56,6 +72,26 @@ describe('DELETE /api/todos/:id', () => {
 
   it('不正なIDで400を返す', async () => {
     const res = await app.request('/api/todos/-1', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toContain('IDは正の整数で指定してください')
+  })
+
+  it('文字列IDで400を返す', async () => {
+    const res = await app.request('/api/todos/abc', {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.message).toContain('IDは正の整数で指定してください')
+  })
+
+  it('小数IDで400を返す', async () => {
+    const res = await app.request('/api/todos/1.5', {
       method: 'DELETE',
     })
 

--- a/src/todo/application/delete-todo.usecase.ts
+++ b/src/todo/application/delete-todo.usecase.ts
@@ -1,0 +1,10 @@
+import { findTodoById, deleteTodo as deleteTodoFromDb } from '../infrastructure/todo.repository.js'
+import { TodoNotFoundError } from './errors.js'
+
+export async function deleteTodo(id: number): Promise<void> {
+  const todo = await findTodoById(id)
+  if (!todo) {
+    throw new TodoNotFoundError(id)
+  }
+  await deleteTodoFromDb(id)
+}

--- a/src/todo/application/delete-todo.usecase.ts
+++ b/src/todo/application/delete-todo.usecase.ts
@@ -1,10 +1,5 @@
-import { findTodoById, deleteTodo as deleteTodoFromDb } from '../infrastructure/todo.repository.js'
-import { TodoNotFoundError } from './errors.js'
+import { deleteTodo as deleteTodoFromDb } from '../infrastructure/todo.repository.js'
 
 export async function deleteTodo(id: number): Promise<void> {
-  const todo = await findTodoById(id)
-  if (!todo) {
-    throw new TodoNotFoundError(id)
-  }
   await deleteTodoFromDb(id)
 }

--- a/src/todo/presentation/todo.route.ts
+++ b/src/todo/presentation/todo.route.ts
@@ -4,6 +4,7 @@ import { updateTodoSchema } from '../application/dto/update-todo.dto.js'
 import { listTodosQuerySchema } from '../application/dto/list-todos-query.dto.js'
 import { createTodo } from '../application/create-todo.usecase.js'
 import { updateTodo } from '../application/update-todo.usecase.js'
+import { deleteTodo } from '../application/delete-todo.usecase.js'
 import { DuplicateTodoError, TodoNotFoundError } from '../application/errors.js'
 import type { TodoResponse } from '../application/dto/create-todo.dto.js'
 
@@ -101,8 +102,15 @@ todoRoute.delete('/:id', async (c) => {
     return c.json({ message: 'IDは正の整数で指定してください' }, 400)
   }
 
-  // TODO: Replace with usecase
-  return c.body(null, 204)
+  try {
+    await deleteTodo(id)
+    return c.body(null, 204)
+  } catch (e) {
+    if (e instanceof TodoNotFoundError) {
+      return c.json({ message: e.message }, 404)
+    }
+    throw e
+  }
 })
 
 export { todoRoute }


### PR DESCRIPTION
## 概要
`deleteTodo` usecaseを実装し、エンドポイントのモックをusecase呼び出しに置き換える。インテグレーションテストを追加する。

## 親Issue
#32 TODO削除API

## 関連PR
- 前: #37（このPRのbase）
- 次: なし（最後のPR）

## 変更内容
- `src/todo/application/delete-todo.usecase.ts` を作成（存在確認→物理削除）
- `src/todo/presentation/todo.route.ts` のDELETEハンドラをusecase呼び出しに置き換え
  - `TodoNotFoundError` → 404 レスポンス
- `src/__tests__/delete-todo.test.ts` を作成
  - 正常系: 削除成功で204が返る
  - 正常系: 削除後にDBからレコードが消えている
  - 異常系: 存在しないIDで404を返す
  - 異常系: 不正なIDで400を返す

---
Closes #35